### PR TITLE
Update Gradle wrapper so Java 13+ can build

### DIFF
--- a/libgdx-sample-app/gradle/wrapper/gradle-wrapper.properties
+++ b/libgdx-sample-app/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.4.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.7.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
Gradle 6.7.1 is current, and was released about 15 days ago. Gradle 5.4.1 is over a year and a half old. I am able to build with this change using Java 15 (and ByteCoder seems to be compatible with at least Java 14), so it doesn't seem to break anything. It's possible source-maps may not work because I'm using Java 15, or it may be some other cause, but when the demo throws an Exception, the source map file and line number are visible but the source is not.